### PR TITLE
Update dashing devel_branch to match rosdistro source entry

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -37,7 +37,7 @@ tracks:
       -i :{release_inc} --os-name debian --os-not-required
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc}
-    devel_branch: master
+    devel_branch: dashing
     last_version: 6.0.1
     name: yaml_cpp_vendor
     patches: null


### PR DESCRIPTION
This PR from an automated script updates the devel_branch for dashing to match the source branch as specified in https://github.com/ros/rosdistro/dashing/distribution.yaml .

Links to https://github.com/ros2/ros2/issues/963 .
