### PR TITLE
Update foxy devel_branch to match rosdistro source entry

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -85,7 +85,7 @@ tracks:
       -i :{release_inc} --os-name debian --os-not-required
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc}
-    devel_branch: master
+    devel_branch: foxy
     last_version: 7.0.2
     name: yaml_cpp_vendor
     patches: null


### PR DESCRIPTION
This PR from an automated script updates the devel_branch for foxy to match the source branch as specified in https://github.com/ros/rosdistro/foxy/distribution.yaml .

Links to https://github.com/ros2/ros2/issues/963 .
